### PR TITLE
Checkout the v0.1.0 tag when getting started

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -178,7 +178,10 @@ First, clone the repository:
 ```bash
 git clone https://github.com/common-fate/iamzero-python-example
 cd iamzero-python-example
+git checkout v0.1.0
 ```
+
+Please note that the `main` branch in this repository is currently under active development and should be considered unstable. We run the `git checkout v0.1.0` command to check out the latest tested and working version.
 
 The script we will run is `iamzero_example.py`. You can inspect it in your code editor to see how IAM Zero is loaded and used. The important two lines in the script are:
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -23,11 +23,14 @@ We don't yet host releases of IAM Zero but you can build the CLI from source. Yo
 - [NodeJS 14](https://nodejs.org/en/download/)
 - [Yarn 1.22](https://classic.yarnpkg.com/en/docs/install)
 
+Please note that the `main` branch in this repository is currently under active development and should be considered unstable. We run the `git checkout v0.1.0` command below to check out the latest tested and working version.
+
 Follow these steps to compile IAM Zero locally:
 
 ```bash
 git clone https://github.com/common-fate/iamzero
 cd iamzero/web
+git checkout v0.1.0
 yarn install --frozen-lockfile
 yarn build
 cd ..
@@ -178,10 +181,7 @@ First, clone the repository:
 ```bash
 git clone https://github.com/common-fate/iamzero-python-example
 cd iamzero-python-example
-git checkout v0.1.0
 ```
-
-Please note that the `main` branch in this repository is currently under active development and should be considered unstable. We run the `git checkout v0.1.0` command to check out the latest tested and working version.
 
 The script we will run is `iamzero_example.py`. You can inspect it in your code editor to see how IAM Zero is loaded and used. The important two lines in the script are:
 


### PR DESCRIPTION
Closes https://github.com/common-fate/iamzero/issues/24. The `main` branch of common-fate/iamzero currently does not allow for the `iamzero local` command to work properly as we are implementing token metadata storage to allow different services sending IAM Zero events to be identified individually. This breaks the local workflow as the `local` command is currently unaware of this.