### PR TITLE
hotfix: Edit URL 404'ing on press

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/common-fate/iamzero-website",
+          editUrl: "https://github.com/common-fate/iamzero-website/blob/main",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
In the app's current state, upon clicking 'Edit this page' the link will 404.

Github will not route to the file, unless `/blob/main` prepends the file path

![image](https://user-images.githubusercontent.com/21688404/129466479-b8d84fec-a34b-4b5a-9d0d-b8e5672653ef.png)

![image](https://user-images.githubusercontent.com/21688404/129466481-cbaa05e2-cf37-4a7b-8ffa-29174fa28fac.png)

Tested on localhost :) 